### PR TITLE
MisSpelling Correction *(and a comemnt or three)

### DIFF
--- a/content/post/2024-01-08-a-day-in-the-life-the-bgp-table/index.markdown
+++ b/content/post/2024-01-08-a-day-in-the-life-the-bgp-table/index.markdown
@@ -83,7 +83,7 @@ That’s all we’ll look at in the first tranche, we’ll focus our attention f
 ![](index_files/figure-html/unnamed-chunk-8-1.gif)<!-- -->
 For IPv4 paths you’re looking on average at around 50 path updates every 30 seconds. For IPv6 it’s slightly lower, at around 47 path updates. While the averages are close, the variance is quite different, a standard deviation of 64.3 and 43 for v4 and v6 respectively.
 
-Instead of looking at the total count of udpates, we can instead look at the total aggregate IP address change. We do this by adding up the total amount of IP addresses across all updates for every 30 second interval, then take the log2() of the sum. So for example: a /22, a /23 and a /24 would be \\(log_2(2^{32-22} + 2^{32-23} + 2^{32-24})\\)
+Instead of looking at the total count of updates, we can instead look at the total aggregate IP address change. We do this by adding up the total amount of IP addresses across all updates for every 30 second interval, then take the log2() of the sum. So for example: a /22, a /23 and a /24 would be \\(log_2(2^{32-22} + 2^{32-23} + 2^{32-24})\\)
 
 Below is the log2() IPv4 address space, viewed as a time series and as a density plot. It shows that on average, every 30 seconds, around 2^16 IP addresses (i.e a /16) change paths in the global routing table, with 95% of time time the change in IP address space is between \\(2^{20.75}\\) (approx. a /11) and \\(2^{13.85}\\) (approx. a /18).
 


### PR DESCRIPTION
Howdy! while reading your post (which made it's way to me via the bgpstuff.net folk (@mellowdrifter)) I noticed a mis-spelling... one I happen to also make a ton while writing udpates.

here's a fix! :) Also, great article, I love seeing people poke/prod at the bgp data in an effort to try and make sense of what's going on.:)

Also a comment or three:
  * `Collected between 6/1/2024 and 7/1/2024, the full dataset consists of 464,673 BGP UPDATE messages received from a peer `

    That seems like a very low number of updates for a month's data? That's just 15.5k / day? or 1 update every 5 seconds... that seems awfully low, actually. In the image (about 140.99.244.0/23) it looks like maybe you are reliant upon a device in AS45270 which is a `customer` of AS4764? Is it possible that the best-path action at 4764 is trimming down a ton of the actual updates you'd see at AS45270? This might mask

  * The splay at the first hop (AS3223) in that same image about 140.99.244.0/23 is REALLY AS4764 selecting between the various peers/upstreams, no? it's just getting a ton of 'all the same' looking updates for the prefix and cycling over them to you/AS45270. I'd bet the selection at AS4764 is happening for some igp-related reason inside AS4764, no?

  * This sort of talk/writeup is really intersting to me, and probably would be interesting for the folks at: iepg.org (meetings happen the Sunday at the start of IETF meeting week - mail to iepg@iepg.org would get you on the schedule I bet :) remote presentations accepted!)

  * this sort of work might ALSO be interesting to the GROW WG folks, (grow@ietf.org)

thanks for the writeup/research! (I hope there's more?) Also, a comment box or pointer to where to better make comments would be cool :)